### PR TITLE
서블릿 예외 처리 - 시작

### DIFF
--- a/exception/src/main/java/hello/exception/servlet/ServletExController.java
+++ b/exception/src/main/java/hello/exception/servlet/ServletExController.java
@@ -1,0 +1,29 @@
+package hello.exception.servlet;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Controller
+public class ServletExController {
+
+    @GetMapping("/error-ex")
+    public void errorEx() {
+        throw new RuntimeException("예외 발생!");
+    }
+
+    @GetMapping("/error-404")
+    public void error404(HttpServletResponse response) throws IOException {
+        response.sendError(404, "404 오류!!");
+    }
+
+    @GetMapping("/error-500")
+    public void error500(HttpServletResponse response) throws IOException {
+        response.sendError(500);
+    }
+
+}

--- a/exception/src/main/resources/application.properties
+++ b/exception/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-
+server.error.whitelabel.enabled=false


### PR DESCRIPTION
## 서블릿은 다음 2가지 방식으로 예외 처리를 지원한다.
- Exception (예외)
- response.sendError(HTTP 상태 코드, 오류 메시지)

### Exception(예외)
- 자바 직접 실행
자바의 메인 메서드를 직접 실행하는 경우 main 이라는 이름의 쓰레드가 실행된다.
실행 도중에 예외를 잡지 못하고 처음 실행한 main() 메서드를 넘어서 예외가 던져지면, 예외 정보를
남기고 해당 쓰레드는 종료된다.

- 웹 애플리케이션
웹 애플리케이션은 사용자 요청별로 별도의 쓰레드가 할당되고, 서블릿 컨테이너 안에서 실행된다.
애플리케이션에서 예외가 발생했는데, 어디선가 try ~ catch로 예외를 잡아서 처리하면 아무런 문제가
없다. 그런데 만약에 애플리케이션에서 예외를 잡지 못하고, 서블릿 밖으로 까지 예외가 전달되면 어떻게
동작할까?
-- > WAS(여기까지 전파) <- 필터 <- 서블릿 <- 인터셉터 <- 컨트롤러(예외발생)


### response.sendError(HTTP 상태 코드, 오류 메시지)
- 오류가 발생했을 때 HttpServletResponse 가 제공하는 sendError 라는 메서드를 사용해도 된다.
이것을 호출한다고 당장 예외가 발생하는 것은 아니지만, 서블릿 컨테이너에게 오류가 발생했다는 점을
전달할 수 있다.
이 메서드를 사용하면 HTTP 상태 코드와 오류 메시지도 추가할 수 있다.
- response.sendError(HTTP 상태 코드)
- response.sendError(HTTP 상태 코드, 오류 메시지)
