### PR TITLE
스프링 부트 - 오류 페이지2

### DIFF
--- a/exception/src/main/resources/application.properties
+++ b/exception/src/main/resources/application.properties
@@ -1,1 +1,6 @@
 server.error.whitelabel.enabled=false
+
+server.error.include-exception=true
+server.error.include-message=on_param
+server.error.include-stacktrace=on_param
+server.error.include-binding-errors=on_param

--- a/exception/src/main/resources/templates/error/500.html
+++ b/exception/src/main/resources/templates/error/500.html
@@ -14,6 +14,21 @@
         <p>오류 화면 입니다.</p>
     </div>
 
+    <ul>
+        <li>오류 정보</li>
+        <ul>
+            <li th:text="|timestamp: ${timestamp}|"></li>
+            <li th:text="|path: ${path}|"></li>
+            <li th:text="|status: ${status}|"></li>
+            <li th:text="|message: ${message}|"></li>
+            <li th:text="|error: ${error}|"></li>
+            <li th:text="|exception: ${exception}|"></li>
+            <li th:text="|errors: ${errors}|"></li>
+            <li th:text="|trace: ${trace}|"></li>
+        </ul>
+        </li>
+    </ul>
+
     <hr class="my-4">
 
 </div> <!-- /container -->


### PR DESCRIPTION
### BasicErrorController가 제공하는 기본 정보들
* timestamp: Fri Feb 05 00:00:00 KST 2021
* status: 400
* error: Bad Request
* exception: org.springframework.validation.BindException
* trace: 예외 trace
* message: Validation failed for object='data'. Error count: 1
* errors: Errors(BindingResult)
* path: 클라이언트 요청 경로 (`/hello`)


### application.properties
- server.error.include-exception=false : exception 포함 여부( true , false )
- server.error.include-message=never : message 포함 여부
- server.error.include-stacktrace=never : trace 포함 여부
- server.error.include-binding-errors=never : errors 포함 여부

- 기본 값이 never 인 부분은 다음 3가지 옵션을 사용할 수 있다.
**never, always, on_param**
- never : 사용하지 않음
- always :항상 사용
- on_param : 파라미터가 있을 때 사용

on_param 은 파라미터가 있으면 해당 정보를 노출한다. 디버그 시 문제를 확인하기 위해 사용할 수 있다.
그런데 이 부분도 개발 서버에서 사용할 수 있지만, 운영 서버에서는 권장하지 않는다. on_param 으로 설정하고 다음과 같이 HTTP 요청시 파라미터를 전달하면 해당 정보들이 model 에 담겨서 뷰 템플릿에서 출력된다


### 스프링 부트 오류 관련 옵션
- server.error.whitelabel.enabled=true : 오류 처리 화면을 못 찾을 시, 스프링 whitelabel 오류 페이지 적용
- server.error.path=/error : 오류 페이지 경로, 스프링이 자동 등록하는 서블릿 글로벌 오류 페이지 경로와 BasicErrorController 오류 컨트롤러 경로에 함께 사용된다.

### 확장 포인트
- 에러 공통 처리 컨트롤러의 기능을 변경하고 싶으면 ErrorController 인터페이스를 상속 받아서
구현하거나 BasicErrorController 상속 받아서 기능을 추가하면 된다.