### PR TITLE
API 예외 처리 - 스프링 부트 기본 오류 처리

### DIFF
--- a/exception/src/main/java/hello/exception/WebServerCustomizer.java
+++ b/exception/src/main/java/hello/exception/WebServerCustomizer.java
@@ -6,7 +6,7 @@ import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
-@Component
+//@Component
 public class WebServerCustomizer implements WebServerFactoryCustomizer<ConfigurableWebServerFactory> {
 
     @Override


### PR DESCRIPTION
## 스프링 부트의 예외 처리
- 앞서 학습했듯이 스프링 부트의 기본 설정은 오류 발생시 /error 를 오류 페이지로 요청한다. BasicErrorController 는 이 경로를 기본으로 받는다. ( server.error.path 로 수정 가능, 기본 경로 /error )

![image](https://user-images.githubusercontent.com/86340380/196617399-7aa1af58-5e08-4ca4-84f1-b257a244bfc6.png)


### 스프링 부트는 BasicErrorController 가 제공하는 기본 정보들을 활용해서 오류 API를 생성해준다.
다음 옵션들을 설정하면 더 자세한 오류 정보를 추가할 수 있다.
- server.error.include-binding-errors=always
- server.error.include-exception=true
- server.error.include-message=always
- server.error.include-stacktrace=always