### PR TITLE
API 예외 처리 - HandlerExceptionResolver 활용

### DIFF
--- a/exception/src/main/java/hello/exception/WebConfig.java
+++ b/exception/src/main/java/hello/exception/WebConfig.java
@@ -3,6 +3,7 @@ package hello.exception;
 import hello.exception.filter.LogFilter;
 import hello.exception.interceptor.LogInterceptor;
 import hello.exception.resolver.MyHandlerExceptionResolver;
+import hello.exception.resolver.UserHandlerExceptionResolver;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -42,5 +43,8 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void extendHandlerExceptionResolvers(List<HandlerExceptionResolver> resolvers) {
         resolvers.add(new MyHandlerExceptionResolver());
+        resolvers.add(new UserHandlerExceptionResolver());
     }
+
+
 }

--- a/exception/src/main/java/hello/exception/api/ApiExceptionController.java
+++ b/exception/src/main/java/hello/exception/api/ApiExceptionController.java
@@ -1,5 +1,6 @@
 package hello.exception.api;
 
+import hello.exception.exception.UserException;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +20,10 @@ public class ApiExceptionController {
 
         if (id.equals("bad")) {
             throw new IllegalArgumentException("잘못된 입력 값");
+        }
+
+        if (id.equals("user-ex")) {
+            throw new UserException("사용자 오류");
         }
 
         return new MemberDto(id, "hello " + id);

--- a/exception/src/main/java/hello/exception/exception/UserException.java
+++ b/exception/src/main/java/hello/exception/exception/UserException.java
@@ -1,0 +1,24 @@
+package hello.exception.exception;
+
+public class UserException extends RuntimeException {
+
+    public UserException() {
+        super();
+    }
+
+    public UserException(String message) {
+        super(message);
+    }
+
+    public UserException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public UserException(Throwable cause) {
+        super(cause);
+    }
+
+    protected UserException(String message, Throwable cause, boolean enableSuppression, boolean writebleStackTrace) {
+        super(message, cause, enableSuppression, writebleStackTrace);
+    }
+}

--- a/exception/src/main/java/hello/exception/resolver/UserHandlerExceptionResolver.java
+++ b/exception/src/main/java/hello/exception/resolver/UserHandlerExceptionResolver.java
@@ -1,0 +1,50 @@
+package hello.exception.resolver;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hello.exception.exception.UserException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+import org.springframework.web.servlet.ModelAndView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class UserHandlerExceptionResolver implements HandlerExceptionResolver {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public ModelAndView resolveException(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+
+        try {
+            if (ex instanceof UserException) {
+                log.info("UserException resolver to 400");
+                String acceptHeader = request.getHeader("accept");
+                response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+
+                if ("application/json".equals(acceptHeader)) {
+                    Map<String, Object> errorResult = new HashMap<>();
+                    errorResult.put("ex", ex.getClass());
+                    errorResult.put("message", ex.getMessage());
+                    String result = objectMapper.writeValueAsString(errorResult);
+
+                    response.setContentType("application/json");
+                    response.setCharacterEncoding("utf-8");
+                    response.getWriter().write(result);
+
+                    return new ModelAndView();
+                } else {
+                    // TEXT/HTML
+                    return new ModelAndView("error/500");
+                }
+            }
+        } catch (IOException e) {
+            log.error("resolver ex", e);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
### 예외를 여기서 마무리하기
- 예외가 발생하면 WAS까지 예외가 던져지고, WAS에서 오류 페이지 정보를 찾아서 다시 /error 를 호출하는 과정은 생각해보면 너무 복잡하다. ExceptionResolver 를 활용하면 예외가 발생했을 때 이런 복잡한 과정 없이 여기에서 문제를 깔끔하게 해결할 수 있다.

### UserException을 만든 후 Controller에서 예외를 추가 후 이 예외를 처리하는 Resolver 생성
**UserException**
![image](https://user-images.githubusercontent.com/86340380/196838596-fbff43df-ae9b-461e-af6a-8e062dbdd852.png)

**ApiExceptionController - 예외 추가**
![image](https://user-images.githubusercontent.com/86340380/196838682-ec52104a-da12-4c6a-b7d4-6a259203fd61.png)

**UserHandlerExceptionResolver**
![image](https://user-images.githubusercontent.com/86340380/196838969-73ec3338-fd5b-45db-b18d-eb4ffeb3f381.png)
![image](https://user-images.githubusercontent.com/86340380/196839003-9f3eeeac-d4c2-4985-944f-d56c0ce6bbac.png)
- HTTP 요청 해더의 ACCEPT 값이 application/json 이면 JSON으로 오류를 내려주고, 그 외 경우에는 error/500에 있는 HTML 오류 페이지를 보여준다.

**WebConfig에 UserHandlerExceptionResolver 추가**
![image](https://user-images.githubusercontent.com/86340380/196839083-f6e6ff0b-3d5e-4b66-8a3c-d4746ff78a04.png)


### 정리
- ExceptionResolver 를 사용하면 컨트롤러에서 예외가 발생해도 ExceptionResolver 에서 예외를 처리해버린다.
따라서 예외가 발생해도 서블릿 컨테이너까지 예외가 전달되지 않고, 스프링 MVC에서 예외 처리는 끝이 난다.
결과적으로 WAS 입장에서는 정상 처리가 된 것이다. 이렇게 예외를 이곳에서 모두 처리할 수 있다는 것이 핵심이다.

- 서블릿 컨테이너까지 예외가 올라가면 복잡하고 지저분하게 추가 프로세스가 실행된다. 반면에 ExceptionResolver 를 사용하면 예외처리가 상당히 깔끔해진다. 그런데 직접 ExceptionResolver 를 구현하려고 하니 상당히 복잡하다. 지금부터 스프링이 제공하는 ExceptionResolver 들을 알아보자.
