### PR TITLE
API 예외 처리 - 스프링이 제공하는 ExceptionResolver2

### DIFF
--- a/exception/src/main/java/hello/exception/api/ApiExceptionController.java
+++ b/exception/src/main/java/hello/exception/api/ApiExceptionController.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -40,6 +41,11 @@ public class ApiExceptionController {
     @GetMapping("/api/response-status-ex2")
     public String responseStatusEx2() {
         throw new ResponseStatusException(HttpStatus.NOT_FOUND, "error.bad", new IllegalArgumentException());
+    }
+
+    @GetMapping("/api/default-handler-ex")
+    public String defaultException(@RequestParam Integer data) {
+        return "ok";
     }
 
     @Data


### PR DESCRIPTION
### DefaultHandlerExceptionResolver
DefaultHandlerExceptionResolver 는 스프링 내부에서 발생하는 스프링 예외를 해결한다.
대표적으로 파라미터 바인딩 시점에 타입이 맞지 않으면 내부에서 TypeMismatchException 이 발생하는데, 이 경우 예외가 발생했기 때문에 그냥 두면 서블릿 컨테이너까지 오류가 올라가고, 결과적으로 500 오류가 발생한다.
그런데 파라미터 바인딩은 대부분 클라이언트가 HTTP 요청 정보를 잘못 호출해서 발생하는 문제이다.
HTTP 에서는 이런 경우 HTTP 상태 코드 400을 사용하도록 되어 있다.
DefaultHandlerExceptionResolver 는 이것을 500 오류가 아니라 HTTP 상태 코드 400 오류로 변경한다.
스프링 내부 오류를 어떻게 처리할지 수 많은 내용이 정의되어 있다.


**코드 확인**
DefaultHandlerExceptionResolver.handleTypeMismatch 를 보면 다음과 같은 코드를 확인할 수 있다.
response.sendError(HttpServletResponse.SC_BAD_REQUEST) (400) 
결국 response.sendError() 를 통해서 문제를 해결한다.


**ApiExceptionController - 추가**
![image](https://user-images.githubusercontent.com/86340380/196855965-1f0f733f-bba2-4dab-a3ff-077e7b774c7e.png)

**실행**
![image](https://user-images.githubusercontent.com/86340380/196856017-418ef565-5b20-4715-b1f1-b5201ad6be62.png)
실행 결과를 보면 HTTP 상태 코드가 400인 것을 확인할 수 있다.
