### PR TITLE
API 예외 처리 - @ControllerAdvice

### DIFF
--- a/exception/src/main/java/hello/exception/exhandler/ApiExceptionV2Controller.java
+++ b/exception/src/main/java/hello/exception/exhandler/ApiExceptionV2Controller.java
@@ -7,35 +7,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.ModelAndView;
 
 @Slf4j
 @RestController
 public class ApiExceptionV2Controller {
-
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ErrorResult illegalExHandle(IllegalArgumentException e) {
-        log.error("[exceptionHandle] ex", e);
-
-        return new ErrorResult("BAD", e.getMessage());
-    }
-
-    @ExceptionHandler
-    public ResponseEntity<ErrorResult> userExHandle(UserException e) {
-        log.error("[exceptionHandle] ex", e);
-        ErrorResult errorResult = new ErrorResult("USER_EX", e.getMessage());
-
-        return new ResponseEntity<>(errorResult, HttpStatus.BAD_REQUEST);
-    }
-
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    @ExceptionHandler
-    public ErrorResult exHandle(Exception e) {
-        log.error("[exceptionHandle ex", e);
-
-        return new ErrorResult("EX", "내부 오류");
-    }
 
     @GetMapping("/api2/members/{id}")
     public MemberDto getMember(@PathVariable("id") String id) {
@@ -51,6 +26,7 @@ public class ApiExceptionV2Controller {
         }
         return new MemberDto(id, "hello " + id);
     }
+
 
     @Data
     @AllArgsConstructor

--- a/exception/src/main/java/hello/exception/exhandler/advice/ExControllerAdvice.java
+++ b/exception/src/main/java/hello/exception/exhandler/advice/ExControllerAdvice.java
@@ -1,0 +1,40 @@
+package hello.exception.exhandler.advice;
+
+import hello.exception.exception.UserException;
+import hello.exception.exhandler.ErrorResult;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice // == @ControllerAdvice와 같음
+public class ExControllerAdvice {
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ErrorResult illegalExHandle(IllegalArgumentException e) {
+        log.error("[exceptionHandle] ex", e);
+
+        return new ErrorResult("BAD", e.getMessage());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorResult> userExHandle(UserException e) {
+        log.error("[exceptionHandle] ex", e);
+        ErrorResult errorResult = new ErrorResult("USER-EX", e.getMessage());
+
+        return new ResponseEntity<>(errorResult, HttpStatus.BAD_REQUEST);
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler
+    public ErrorResult exHandel(Exception e) {
+        log.error("[exceptionHandle] ex", e);
+
+        return new ErrorResult("EX", "내부 오류");
+    }
+
+}

--- a/exception/src/main/java/hello/exception/servlet/ServletExController.java
+++ b/exception/src/main/java/hello/exception/servlet/ServletExController.java
@@ -1,11 +1,17 @@
 package hello.exception.servlet;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.util.StreamUtils;
+import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 @Slf4j
 @Controller
@@ -26,4 +32,10 @@ public class ServletExController {
         response.sendError(500);
     }
 
+    @ResponseBody
+    @PostMapping("/request-body-string-v4")
+    public String requestBodyStringV4(@RequestBody String messageBody) {
+        log.info("messageBody={}", messageBody);
+        return "ok";
+    }
 }


### PR DESCRIPTION
### init
@ExceptionHandler 를 사용해서 예외를 깔끔하게 처리할 수 있게 되었지만, 정상 코드와 예외 처리 코드가 하나의 컨트롤러에 섞여 있다. @ControllerAdvice 또는 @RestControllerAdvice 를 사용하면 둘을 분리할 수 있다.


**ExControllerAdvice**
![image](https://user-images.githubusercontent.com/86340380/196895788-bcf80419-9520-4e62-8328-9b0d21048ed9.png)

**ApiExceptionV2Controller 코드에 있는 @ExceptionHandler 모두 제거**


### @ControllerAdvice
- @ControllerAdvice 는 대상으로 지정한 여러 컨트롤러에 @ExceptionHandler , @InitBinder 기능을 부여해주는 역할을 한다.
- @ControllerAdvice 에 대상을 지정하지 않으면 모든 컨트롤러에 적용된다. (글로벌 적용)
- @RestControllerAdvice 는 @ControllerAdvice 와 같고, @ResponseBody 가 추가되어 있다. @Controller , @RestController 의 차이와 같다.

**대상 컨트롤러 지정 방법**
![image](https://user-images.githubusercontent.com/86340380/196896059-c1f777e1-1fd8-4c6c-91d6-71796a70bfba.png)


###  정리
@ExceptionHandler 와 @ControllerAdvice 를 조합하면 예외를 깔끔하게 해결할 수 있다.